### PR TITLE
[codex] homepage intro text and section order

### DIFF
--- a/src/features/home/HomePage.test.tsx
+++ b/src/features/home/HomePage.test.tsx
@@ -128,9 +128,10 @@ describe('HomePage', () => {
 
     expect(
       screen.getByText(
-        /Inoffizielles Werkzeug zum Durchsuchen, Filtern und Exportieren des\s+offiziellen Grundschutz\+\+-Anwenderkatalogs des BSI\. Kein Angebot\s+des BSI\./,
+        /Werkzeug zum Durchsuchen, Filtern und Exportieren des\s+offiziellen Grundschutz\+\+-Anwenderkatalogs des BSI\. Kein Angebot\s+des BSI\./,
       ),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/Inoffizielles/)).not.toBeInTheDocument();
     expect(screen.getAllByText(/Kein Angebot des BSI/)).toHaveLength(1);
     expect(
       screen.getByText(/2 Praktiken\s+·\s+3 Themen\s+·\s+7 Kontrollen/),
@@ -190,5 +191,21 @@ describe('HomePage', () => {
     });
 
     expect(aboutLink).toHaveAttribute('href', '/about');
+  });
+
+  it('places the Grundschutz++ explanation before the practice register', () => {
+    renderHome();
+
+    const summaryHeading = screen.getByRole('heading', {
+      name: 'Was ist Grundschutz++?',
+    });
+    const practiceRegister = screen.getByRole('region', {
+      name: 'Praktiken-Register',
+    });
+
+    expect(
+      summaryHeading.compareDocumentPosition(practiceRegister) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });

--- a/src/features/home/HomePage.tsx
+++ b/src/features/home/HomePage.tsx
@@ -44,9 +44,8 @@ export function HomePage() {
             Grundschutz++ Navigator
           </h1>
           <p className="type-secondary mt-0.5 text-[var(--color-text-secondary)]">
-            Inoffizielles Werkzeug zum Durchsuchen, Filtern und Exportieren des
-            offiziellen Grundschutz++-Anwenderkatalogs des BSI. Kein Angebot
-            des BSI.
+            Werkzeug zum Durchsuchen, Filtern und Exportieren des offiziellen
+            Grundschutz++-Anwenderkatalogs des BSI. Kein Angebot des BSI.
           </p>
           {catalogStats && (
             <p className="type-meta mt-3 text-[var(--color-text-secondary)] tabular-nums">
@@ -80,6 +79,30 @@ export function HomePage() {
           </p>
         </div>
       </header>
+
+      {catalog && (
+        <section
+          aria-labelledby="grundschutz-summary-heading"
+          className="mt-6 border-t border-[var(--color-border-subtle)] pt-4"
+        >
+          <h2
+            id="grundschutz-summary-heading"
+            className="type-meta text-[var(--color-text-secondary)]"
+          >
+            Was ist Grundschutz++?
+          </h2>
+          <p className="mt-2 text-sm leading-relaxed text-[var(--color-text-primary)]">
+            Grundschutz++ ist ein fortentwickelter Anwenderkatalog des BSI im
+            Kontext des IT-Grundschutzes. Er liegt maschinenlesbar im
+            OSCAL-Format vor und verbindet methodische mit konkreten
+            technisch-organisatorischen Anforderungen. Mehr dazu unter{' '}
+            <Link to="/about" className="catalog-link-color">
+              Über das Projekt
+            </Link>
+            .
+          </p>
+        </section>
+      )}
 
       {/* Practice register */}
       {loading && (
@@ -132,30 +155,6 @@ export function HomePage() {
               </Link>
             ))}
           </div>
-        </section>
-      )}
-
-      {catalog && (
-        <section
-          aria-labelledby="grundschutz-summary-heading"
-          className="mt-6 border-t border-[var(--color-border-subtle)] pt-4"
-        >
-          <h2
-            id="grundschutz-summary-heading"
-            className="type-meta text-[var(--color-text-secondary)]"
-          >
-            Was ist Grundschutz++?
-          </h2>
-          <p className="mt-2 text-sm leading-relaxed text-[var(--color-text-primary)]">
-            Grundschutz++ ist ein fortentwickelter Anwenderkatalog des BSI im
-            Kontext des IT-Grundschutzes. Er liegt maschinenlesbar im
-            OSCAL-Format vor und verbindet methodische mit konkreten
-            technisch-organisatorischen Anforderungen. Mehr dazu unter{' '}
-            <Link to="/about" className="catalog-link-color">
-              Über das Projekt
-            </Link>
-            .
-          </p>
         </section>
       )}
 


### PR DESCRIPTION
## What changed
- Removed the word "Inoffizielles" from the homepage hero copy.
- Moved the "Was ist Grundschutz++?" explanation above the practice register.
- Updated the homepage test coverage to assert the new copy and document order.

## Why
The homepage should use the cleaner approved wording and present the explanatory section before the table, matching the requested content order.

## Validation
- `npm run test -- src/features/home/HomePage.test.tsx`
- `npm run lint`
- `npm run test:coverage`