### PR TITLE
[codex] simplify about disclaimer wording

### DIFF
--- a/src/features/home/HomePage.test.tsx
+++ b/src/features/home/HomePage.test.tsx
@@ -128,9 +128,10 @@ describe('HomePage', () => {
 
     expect(
       screen.getByText(
-        /Inoffizielles Werkzeug zum Durchsuchen, Filtern und Exportieren des\s+offiziellen Grundschutz\+\+-Anwenderkatalogs des BSI\. Kein Angebot\s+des BSI\./,
+        /Werkzeug zum Durchsuchen, Filtern und Exportieren des\s+offiziellen Grundschutz\+\+-Anwenderkatalogs des BSI\. Kein Angebot\s+des BSI\./,
       ),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/Inoffizielles/)).not.toBeInTheDocument();
     expect(screen.getAllByText(/Kein Angebot des BSI/)).toHaveLength(1);
     expect(
       screen.getByText(/2 Praktiken\s+·\s+3 Themen\s+·\s+7 Kontrollen/),
@@ -190,5 +191,21 @@ describe('HomePage', () => {
     });
 
     expect(aboutLink).toHaveAttribute('href', '/about');
+  });
+
+  it('places the Grundschutz++ explanation before the practice register', () => {
+    renderHome();
+
+    const summaryHeading = screen.getByRole('heading', {
+      name: 'Was ist Grundschutz++?',
+    });
+    const practiceRegister = screen.getByRole('region', {
+      name: 'Praktiken-Register',
+    });
+
+    expect(
+      summaryHeading.compareDocumentPosition(practiceRegister) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });

--- a/src/features/home/HomePage.tsx
+++ b/src/features/home/HomePage.tsx
@@ -44,9 +44,8 @@ export function HomePage() {
             Grundschutz++ Navigator
           </h1>
           <p className="type-secondary mt-0.5 text-[var(--color-text-secondary)]">
-            Inoffizielles Werkzeug zum Durchsuchen, Filtern und Exportieren des
-            offiziellen Grundschutz++-Anwenderkatalogs des BSI. Kein Angebot
-            des BSI.
+            Werkzeug zum Durchsuchen, Filtern und Exportieren des offiziellen
+            Grundschutz++-Anwenderkatalogs des BSI. Kein Angebot des BSI.
           </p>
           {catalogStats && (
             <p className="type-meta mt-3 text-[var(--color-text-secondary)] tabular-nums">
@@ -80,6 +79,30 @@ export function HomePage() {
           </p>
         </div>
       </header>
+
+      {catalog && (
+        <section
+          aria-labelledby="grundschutz-summary-heading"
+          className="mt-6 border-t border-[var(--color-border-subtle)] pt-4"
+        >
+          <h2
+            id="grundschutz-summary-heading"
+            className="type-meta text-[var(--color-text-secondary)]"
+          >
+            Was ist Grundschutz++?
+          </h2>
+          <p className="mt-2 text-sm leading-relaxed text-[var(--color-text-primary)]">
+            Grundschutz++ ist ein fortentwickelter Anwenderkatalog des BSI im
+            Kontext des IT-Grundschutzes. Er liegt maschinenlesbar im
+            OSCAL-Format vor und verbindet methodische mit konkreten
+            technisch-organisatorischen Anforderungen. Mehr dazu unter{' '}
+            <Link to="/about" className="catalog-link-color">
+              Über das Projekt
+            </Link>
+            .
+          </p>
+        </section>
+      )}
 
       {/* Practice register */}
       {loading && (
@@ -132,30 +155,6 @@ export function HomePage() {
               </Link>
             ))}
           </div>
-        </section>
-      )}
-
-      {catalog && (
-        <section
-          aria-labelledby="grundschutz-summary-heading"
-          className="mt-6 border-t border-[var(--color-border-subtle)] pt-4"
-        >
-          <h2
-            id="grundschutz-summary-heading"
-            className="type-meta text-[var(--color-text-secondary)]"
-          >
-            Was ist Grundschutz++?
-          </h2>
-          <p className="mt-2 text-sm leading-relaxed text-[var(--color-text-primary)]">
-            Grundschutz++ ist ein fortentwickelter Anwenderkatalog des BSI im
-            Kontext des IT-Grundschutzes. Er liegt maschinenlesbar im
-            OSCAL-Format vor und verbindet methodische mit konkreten
-            technisch-organisatorischen Anforderungen. Mehr dazu unter{' '}
-            <Link to="/about" className="catalog-link-color">
-              Über das Projekt
-            </Link>
-            .
-          </p>
         </section>
       )}
 

--- a/src/features/pages/AboutPage.test.tsx
+++ b/src/features/pages/AboutPage.test.tsx
@@ -139,7 +139,7 @@ describe('AboutPage', () => {
     render(<AboutPage />);
 
     expect(
-      screen.getAllByText(/Die Anwendung ist ein inoffizielles Werkzeug und kein Angebot des BSI\./),
+      screen.getAllByText(/Die Anwendung ist kein Angebot des BSI\./),
     ).toHaveLength(1);
   });
 

--- a/src/features/pages/AboutPage.tsx
+++ b/src/features/pages/AboutPage.tsx
@@ -225,7 +225,7 @@ export function AboutPage() {
           <h1 className="type-page-title">Über das Projekt</h1>
           <p className="type-secondary mt-0.5">
             Der Grundschutz++ Navigator erschließt den offiziellen BSI-Katalog im Browser.
-            Die Anwendung ist ein inoffizielles Werkzeug und kein Angebot des BSI.
+            Die Anwendung ist kein Angebot des BSI.
           </p>
           <p className="type-meta mt-3">
             Clientseitige Verarbeitung &middot; Laufzeit-Verifikation per SHA-256 &middot; Build-Provenance via GitHub Actions


### PR DESCRIPTION
## What changed
- Simplified the `/about` disclaimer from "Die Anwendung ist ein inoffizielles Werkzeug und kein Angebot des BSI." to "Die Anwendung ist kein Angebot des BSI."
- Updated the About page test to assert the new wording.

## Why
The shorter wording is the requested copy on `/about` and avoids the extra phrasing that is no longer needed.

## Validation
- `npm run test -- src/features/pages/AboutPage.test.tsx`
- `npm run lint`
- `npm run test:coverage`

## Stack
This PR is stacked on top of the open homepage copy-order PR so the changes stay isolated by issue.