### PR TITLE
GRU-172: tighten homepage spacing rhythm

### DIFF
--- a/src/features/home/HomePage.test.tsx
+++ b/src/features/home/HomePage.test.tsx
@@ -208,4 +208,23 @@ describe('HomePage', () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
+
+  it('uses tighter hero spacing and a clearer gap before the practice register', () => {
+    renderHome();
+
+    const pageHeader = screen.getByRole('heading', {
+      name: 'Grundschutz++ Navigator',
+    }).closest('header');
+    const summarySection = screen.getByRole('heading', {
+      name: 'Was ist Grundschutz++?',
+    }).closest('section');
+    const practiceRegister = screen.getByRole('region', {
+      name: 'Praktiken-Register',
+    });
+
+    expect(pageHeader).toHaveClass('pb-6');
+    expect(summarySection).toHaveClass('pt-6');
+    expect(summarySection).not.toHaveClass('mt-6');
+    expect(practiceRegister).toHaveClass('mt-8');
+  });
 });

--- a/src/features/home/HomePage.tsx
+++ b/src/features/home/HomePage.tsx
@@ -35,9 +35,9 @@ export function HomePage() {
     : null;
 
   return (
-    <div className="max-w-3xl mx-auto px-6 pt-8 pb-12">
+    <div className="mx-auto max-w-3xl px-6 pt-8 pb-12">
       {/* Header */}
-      <header className="flex items-start gap-3.5 pb-8">
+      <header className="flex items-start gap-3.5 pb-6">
         <IconShield className="w-9 h-9 shrink-0 text-[var(--color-accent-default)]" />
         <div className="min-w-0">
           <h1 className="type-page-title text-[var(--color-text-primary)]">
@@ -83,7 +83,7 @@ export function HomePage() {
       {catalog && (
         <section
           aria-labelledby="grundschutz-summary-heading"
-          className="mt-6 border-t border-[var(--color-border-subtle)] pt-4"
+          className="border-t border-[var(--color-border-subtle)] pt-6"
         >
           <h2
             id="grundschutz-summary-heading"
@@ -91,7 +91,7 @@ export function HomePage() {
           >
             Was ist Grundschutz++?
           </h2>
-          <p className="mt-2 text-sm leading-relaxed text-[var(--color-text-primary)]">
+          <p className="mt-3 text-sm leading-relaxed text-[var(--color-text-primary)]">
             Grundschutz++ ist ein fortentwickelter Anwenderkatalog des BSI im
             Kontext des IT-Grundschutzes. Er liegt maschinenlesbar im
             OSCAL-Format vor und verbindet methodische mit konkreten
@@ -116,7 +116,7 @@ export function HomePage() {
       )}
 
       {catalog && (
-        <section aria-label="Praktiken-Register">
+        <section aria-label="Praktiken-Register" className="mt-8">
           {/* Column header — same grid as data rows */}
           <div className="grid grid-cols-[3.5rem_1fr] sm:grid-cols-[3.5rem_1fr_4.5rem_4rem] items-baseline gap-x-3 px-4 pb-2">
             <span className="type-secondary text-[var(--color-text-muted)]">


### PR DESCRIPTION
## Summary
- reduce the vertical gap between the homepage hero and the Grundschutz++ explanation
- add clearer separation between the explanation copy and the practice register
- add a focused homepage regression test for the spacing classes

## Validation
- `npm run test -- src/features/home/HomePage.test.tsx`
- `npm run lint -- src/features/home/HomePage.tsx src/features/home/HomePage.test.tsx`
- browser check on `http://127.0.0.1:5174/`
