### PR TITLE
GRU-177 CSP-Meta-Tag setzen

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,6 +161,20 @@ Jeder Katalog wird zum Build-Zeitpunkt mit einem SHA-256 Hash versehen. Zur Lauf
 
 Siehe [INTEGRITY.md](./INTEGRITY.md) für Details.
 
+## Content Security Policy
+
+GitHub Pages erlaubt in diesem Setup keine projektspezifischen HTTP-Security-Header. Die Produktionsanwendung setzt deshalb eine Meta-CSP in `index.html`:
+
+```text
+default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';
+```
+
+Die Policy begrenzt Skripte, Datenabrufe, Bilder und Schriften auf die ausgelieferte Anwendung, blockiert Plugin-Objekte und beschränkt `<base>` sowie Form-Ziele auf dieselbe Origin. `font-src 'self'` ist möglich, weil die UI-Schriften lokal unter `public/fonts/` ausgeliefert werden.
+
+`style-src 'unsafe-inline'` bleibt bewusst gesetzt, weil Teile der React-/Tailwind-Oberfläche dynamische Inline-Styles für Interaktionen verwenden. Das ist ein eingegrenzter Tradeoff: Skripte bleiben weiterhin auf `'self'` beschränkt, und die Anwendung lädt keine externen Stylesheet-Origins.
+
+`frame-ancestors` kann nach CSP-Spezifikation nicht wirksam per Meta-Tag gesetzt werden und würde in Chromium als ignorierte Direktive protokolliert. Ein echtes Framing-Verbot muss als HTTP-CSP-Header auf der Hosting-Schicht gesetzt werden; GitHub Pages stellt dafür in diesem Projekt derzeit keinen Mechanismus bereit.
+
 ## Import-Alias
 
 Das Projekt verwendet den `@/` Alias für projektinterne Importe:

--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Grundschutz++ Navigator — BSI Anwenderkatalog durchsuchen, filtern und exportieren." />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';"
+    />
     <title>Grundschutz++ Navigator</title>
   </head>
   <body class="bg-slate-100 text-slate-900 selection:bg-sky-200">


### PR DESCRIPTION
## Summary
- add a production CSP meta policy to index.html
- document the CSP directive rationale and the inline-style tradeoff in docs/ARCHITECTURE.md
- document the frame-ancestors limitation for CSP delivered by meta tags on GitHub Pages

## Stacking
This PR is stacked on GRU-178 / PR #13 so font-src 'self' is valid after the font self-hosting change.

## Validation
- npm run build
- npm run build:local
- local production preview at http://127.0.0.1:4173/ with Playwright: app loaded, CSP meta was present, and no CSP-related console messages were captured

## Deviation
The original issue text included frame-ancestors 'none'. Browsers ignore frame-ancestors in meta-delivered CSP and Chromium logs that as an error, so this PR omits the inert directive and documents that a real framing restriction requires an HTTP CSP header on the hosting layer.

Linear: GRU-177