### PR TITLE
GRU-179 CSV-Injection schließen

### DIFF
--- a/src/features/export/csvExport.test.ts
+++ b/src/features/export/csvExport.test.ts
@@ -125,6 +125,7 @@ describe('escapeCSVField', () => {
     ['at sign', '@DDE()', "'@DDE()"],
     ['tab', '\tIDS', "'\tIDS"],
     ['carriage return', '\r\nFOO', '"\'\r\nFOO"'],
+    ['line feed', '\n=HYPERLINK("https://example.invalid")', '"\'\n=HYPERLINK(""https://example.invalid"")"'],
   ])('prefixes formula-looking values starting with %s', (_label, input, expected) => {
     expect(escapeCSVField(input)).toBe(expected);
   });

--- a/src/features/export/csvExport.test.ts
+++ b/src/features/export/csvExport.test.ts
@@ -117,6 +117,25 @@ describe('escapeCSVField', () => {
   it('handles carriage returns', () => {
     expect(escapeCSVField('line1\rline2')).toBe('"line1\rline2"');
   });
+
+  it.each([
+    ['equals sign', '=cmd|calc!A0', "'=cmd|calc!A0"],
+    ['plus sign', '+1+1', "'+1+1"],
+    ['minus sign', '-2', "'-2"],
+    ['at sign', '@DDE()', "'@DDE()"],
+    ['tab', '\tIDS', "'\tIDS"],
+    ['carriage return', '\r\nFOO', '"\'\r\nFOO"'],
+  ])('prefixes formula-looking values starting with %s', (_label, input, expected) => {
+    expect(escapeCSVField(input)).toBe(expected);
+  });
+
+  it.each(['MUSS', 'ARCH.1.1'])('keeps harmless value %s unchanged', (value) => {
+    expect(escapeCSVField(value)).toBe(value);
+  });
+
+  it('protects and quotes formula-looking values containing semicolons', () => {
+    expect(escapeCSVField('=SUM(1;2)')).toBe('"\'=SUM(1;2)"');
+  });
 });
 
 /* ------------------------------------------------------------------ */

--- a/src/features/export/csvExport.ts
+++ b/src/features/export/csvExport.ts
@@ -3,19 +3,24 @@ import { getControlLinkTargetsByRelation } from '@/domain/controlRelationships';
 
 /**
  * Escape a field value for CSV output.
+ * - Prefixes Excel/LibreOffice formula-looking values with an apostrophe
  * - Wraps in double quotes if value contains semicolons, quotes, or newlines
  * - Escapes internal double quotes by doubling them
  */
+const FORMULA_PREFIX = /^[=+\-@\t\r]/u;
+
 export function escapeCSVField(value: string): string {
+  const safeValue = FORMULA_PREFIX.test(value) ? `'${value}` : value;
+
   if (
-    value.includes(';') ||
-    value.includes('"') ||
-    value.includes('\n') ||
-    value.includes('\r')
+    safeValue.includes(';') ||
+    safeValue.includes('"') ||
+    safeValue.includes('\n') ||
+    safeValue.includes('\r')
   ) {
-    return `"${value.replace(/"/g, '""')}"`;
+    return `"${safeValue.replace(/"/g, '""')}"`;
   }
-  return value;
+  return safeValue;
 }
 
 /**

--- a/src/features/export/csvExport.ts
+++ b/src/features/export/csvExport.ts
@@ -7,7 +7,7 @@ import { getControlLinkTargetsByRelation } from '@/domain/controlRelationships';
  * - Wraps in double quotes if value contains semicolons, quotes, or newlines
  * - Escapes internal double quotes by doubling them
  */
-const FORMULA_PREFIX = /^[=+\-@\t\r]/u;
+const FORMULA_PREFIX = /^[=+\-@\t\r\n]/u;
 
 export function escapeCSVField(value: string): string {
   const safeValue = FORMULA_PREFIX.test(value) ? `'${value}` : value;


### PR DESCRIPTION
## Summary
- prefix CSV fields that start with Excel/LibreOffice formula trigger characters
- keep existing semicolon, quote, LF, and CR CSV escaping behavior
- add Vitest coverage for dangerous prefixes, harmless values, and formula-plus-semicolon quoting

## Validation
- `npm run test` (27 files, 256 tests)

Linear: GRU-179