### PR TITLE
GRU-182 Catalog-Sync manuell reviewen

### DIFF
--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -83,6 +83,28 @@ jobs:
             echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Prepare sync PR body
+        if: steps.compare.outputs.changed == 'true'
+        env:
+          SNAPSHOT_SHA: ${{ steps.compare.outputs.snapshot_commit_sha }}
+          CHANGE_SUMMARY: ${{ steps.compare.outputs.change_summary }}
+        run: |
+          {
+            echo "## BSI-Katalog-Aenderungen"
+            echo ""
+            printf '%s\n' "$CHANGE_SUMMARY"
+            echo ""
+            printf '**BSI-Snapshot:** [`%s`](https://github.com/BSI-Bund/Stand-der-Technik-Bibliothek/commit/%s)\n' \
+              "${SNAPSHOT_SHA}" "${SNAPSHOT_SHA}"
+            echo ""
+            echo "## Review"
+            echo ""
+            echo "Dieser Sync-PR wird bewusst nicht automatisch gemerged."
+            echo "GitHub-Review ist bei \`dfurater\` angefragt; die fachliche Review-Erwartung liegt bei Codex/Claude Code vor dem manuellen Merge."
+            echo ""
+            echo "*Erstellt automatisch durch den taeglichen Katalog-Sync.*"
+          } > /tmp/pr-body.md
+
       - name: Create sync branch and PR
         id: create
         if: steps.compare.outputs.changed == 'true' && steps.idempotency.outputs.create_pr == 'true'
@@ -91,7 +113,6 @@ jobs:
           BRANCH: ${{ steps.idempotency.outputs.branch }}
           BRANCH_EXISTS: ${{ steps.idempotency.outputs.branch_exists }}
           SNAPSHOT_SHA: ${{ steps.compare.outputs.snapshot_commit_sha }}
-          CHANGE_SUMMARY: ${{ steps.compare.outputs.change_summary }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -110,17 +131,6 @@ jobs:
             git push --force-with-lease origin "$BRANCH"
           fi
 
-          {
-            echo "## BSI-Katalog-Aenderungen"
-            echo ""
-            printf '%s\n' "$CHANGE_SUMMARY"
-            echo ""
-            printf '**BSI-Snapshot:** [`%s`](https://github.com/BSI-Bund/Stand-der-Technik-Bibliothek/commit/%s)\n' \
-              "${SNAPSHOT_SHA}" "${SNAPSHOT_SHA}"
-            echo ""
-            echo '*Erstellt automatisch durch den taeglichen Katalog-Sync.*'
-          } > /tmp/pr-body.md
-
           PR_URL=$(gh pr create \
             --title "chore(ci): BSI-Katalog-Sync ${SNAPSHOT_SHA:0:12}" \
             --body-file /tmp/pr-body.md \
@@ -131,7 +141,7 @@ jobs:
           PR_NUMBER=$(gh pr view "$PR_URL" --json number --jq .number)
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
-      - name: Merge sync PR
+      - name: Request manual sync PR review
         if: steps.compare.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -142,14 +152,12 @@ jobs:
 
           PR_NUMBER="${PR_NUMBER_CREATE:-$PR_NUMBER_EXISTING}"
           if [ -z "$PR_NUMBER" ]; then
-            echo "Kein Sync-PR gefunden, kann nicht mergen." >&2
+            echo "Kein Sync-PR gefunden, kann keine Review anfragen." >&2
             exit 1
           fi
 
-          MERGE_OUTPUT_FILE=/tmp/gh-pr-merge-output.txt
-          if gh pr merge --squash --delete-branch "$PR_NUMBER" >"$MERGE_OUTPUT_FILE" 2>&1; then
-            cat "$MERGE_OUTPUT_FILE"
-          else
-            cat "$MERGE_OUTPUT_FILE" >&2
-            exit 1
-          fi
+          gh pr edit "$PR_NUMBER" \
+            --body-file /tmp/pr-body.md \
+            --add-reviewer dfurater
+
+          echo "Sync-PR #$PR_NUMBER bleibt fuer manuelle Review und Merge offen."

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ IT-Sicherheitsbeauftragte, Berater:innen, Auditor:innen, Studierende und alle, d
 - **Lizenz der Katalogdaten:** [Creative Commons BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.de)
 - **Datenhaltung:** Die Katalogdaten werden **beim Build** aus dem BSI-Repository geladen. Im App-Repository wird keine Kopie gehalten.
 - **Integrität:** Ein fixierter Upstream-Commit (`upstream-manifest.json`) plus SHA-256-Verify zur Laufzeit macht nachvollziehbar, welche Katalogversion angezeigt wird. Details: [`docs/INTEGRITY.md`](docs/INTEGRITY.md).
-- **Aktualität:** Ein täglicher Workflow um 06:00 UTC prüft auf Upstream-Änderungen und öffnet bei Bedarf einen Pull Request.
+- **Aktualität:** Ein täglicher Workflow um 06:00 UTC prüft auf Upstream-Änderungen und öffnet bei Bedarf einen Pull Request. Catalog-Sync-PRs werden bewusst nicht automatisch gemerged; sie müssen manuell geprüft und gemerged werden.
 
 ## Datenschutz
 
@@ -90,7 +90,7 @@ Tiefe:
 
 ## Deployment
 
-Pushes nach `main` triggern den Deploy-Workflow: Katalog ziehen → Tests → Build → [SLSA-Provenance-Attestation](https://slsa.dev/) → GitHub Pages. Zusätzlich läuft täglich um 06:00 UTC ein Upstream-Sync, der bei Änderungen am BSI-Katalog automatisch einen Pull Request öffnet.
+Pushes nach `main` triggern den Deploy-Workflow: Katalog ziehen → Tests → Build → [SLSA-Provenance-Attestation](https://slsa.dev/) → GitHub Pages. Zusätzlich läuft täglich um 06:00 UTC ein Upstream-Sync, der bei Änderungen am BSI-Katalog automatisch einen Pull Request öffnet. Dieser Sync-PR bleibt für manuelle Review offen und wird nicht automatisch gemerged.
 
 ## Beitragen
 


### PR DESCRIPTION
## Summary
- remove the automatic `gh pr merge --squash --delete-branch` catalog-sync step
- update created and existing sync PRs with the generated change summary, BSI snapshot commit, and manual review note
- request `dfurater` as the concrete GitHub reviewer for sync PRs
- document in README that catalog-sync PRs stay open for manual review and merge

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/update-catalog.yml'); puts 'yaml ok'"`
- `rg "gh pr merge|--delete-branch|Merge sync PR" .github/workflows/update-catalog.yml` returned no matches

## Deviation
`AGENTS.md` is ignored by this repository (`.gitignore:42`) as a local tool settings file, so I did not force-add it to the PR. The tracked README and workflow document/enforce the manual review gate.

Linear: GRU-182