### PR TITLE
GRU-181 FlexSearch-URL in LizenzenPage korrigieren

### DIFF
--- a/src/features/pages/LizenzenPage.tsx
+++ b/src/features/pages/LizenzenPage.tsx
@@ -76,7 +76,7 @@ export function LizenzenPage() {
               name: 'FlexSearch',
               version: '0.8.x',
               license: 'Apache-2.0',
-              url: 'https://github.com/nicxtreme/flexsearch',
+              url: 'https://github.com/nextapps-de/flexsearch',
             },
             {
               name: 'React Router',


### PR DESCRIPTION
## Summary
- correct the FlexSearch license/source link to nextapps-de/flexsearch
- verified package major versions against package.json
- checked third-party license links for HTTP 200 responses

## Validation
- npm run lint
- curl HTTP checks returned 200 for React, Vite, Tailwind CSS, FlexSearch, React Router, Inter, IBM Plex Sans, and TypeScript links

Linear: GRU-181