### PR TITLE
GRU-192 verifyCatalogIntegrity-Wrapper entfernen

### DIFF
--- a/src/domain/integrity.test.ts
+++ b/src/domain/integrity.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   computeSHA256,
-  verifyCatalogIntegrity,
+  verifyArtifactIntegrity,
   fetchJsonDocument,
   fetchProvenance,
   fetchCatalogWithBuffer,
@@ -75,10 +75,10 @@ describe('computeSHA256', () => {
 });
 
 /* ------------------------------------------------------------------ */
-/*  verifyCatalogIntegrity                                             */
+/*  verifyArtifactIntegrity                                            */
 /* ------------------------------------------------------------------ */
 
-describe('verifyCatalogIntegrity', () => {
+describe('verifyArtifactIntegrity', () => {
   it('returns valid=true when hash matches', async () => {
     const content = '{"catalog": "test"}';
     const buffer = textToBuffer(content);
@@ -92,7 +92,7 @@ describe('verifyCatalogIntegrity', () => {
       },
     });
 
-    const result = await verifyCatalogIntegrity(buffer, metadata);
+    const result = await verifyArtifactIntegrity(buffer, metadata);
     expect(result.valid).toBe(true);
     expect(result.computedHash).toBe(expectedHash);
     expect(result.expectedHash).toBe(expectedHash);
@@ -110,7 +110,7 @@ describe('verifyCatalogIntegrity', () => {
       },
     });
 
-    const result = await verifyCatalogIntegrity(buffer, metadata);
+    const result = await verifyArtifactIntegrity(buffer, metadata);
     expect(result.valid).toBe(false);
     expect(result.computedHash).not.toBe(result.expectedHash);
   });
@@ -128,7 +128,7 @@ describe('verifyCatalogIntegrity', () => {
       },
     });
 
-    const result = await verifyCatalogIntegrity(
+    const result = await verifyArtifactIntegrity(
       textToBuffer(tamperedContent),
       metadata,
     );
@@ -151,7 +151,7 @@ describe('verifyCatalogIntegrity', () => {
       },
     });
 
-    const result = await verifyCatalogIntegrity(buffer, metadata);
+    const result = await verifyArtifactIntegrity(buffer, metadata);
     expect(result.sourceCommit).toBe('commit-xyz');
     expect(result.fetchedAt).toBe('2026-01-01T00:00:00Z');
   });

--- a/src/domain/integrity.ts
+++ b/src/domain/integrity.ts
@@ -26,20 +26,6 @@ export async function computeSHA256(buffer: ArrayBuffer): Promise<string> {
     .join('');
 }
 
-/**
- * Verify the integrity of a loaded catalog against its provenance metadata.
- *
- * @param catalogBuffer - The raw bytes of the catalog JSON file
- * @param metadata - The provenance metadata (from catalog-metadata.json)
- * @returns Verification result with match status and details
- */
-export async function verifyCatalogIntegrity(
-  catalogBuffer: ArrayBuffer,
-  metadata: CatalogProvenance,
-): Promise<VerificationResult> {
-  return verifyArtifactIntegrity(catalogBuffer, metadata);
-}
-
 export async function verifyArtifactIntegrity(
   artifactBuffer: ArrayBuffer,
   metadata: IntegrityMetadata,

--- a/src/state/CatalogContext.tsx
+++ b/src/state/CatalogContext.tsx
@@ -26,7 +26,6 @@ import {
   fetchProvenance,
   fetchVocabularyProvenance,
   verifyArtifactIntegrity,
-  verifyCatalogIntegrity,
 } from '@/domain/integrity';
 
 /* ------------------------------------------------------------------ */
@@ -173,7 +172,7 @@ export function CatalogProvider({
         try {
           provenance = await fetchProvenance(metadataUrl);
           if (!cancelled) {
-            verification = await verifyCatalogIntegrity(buffer, provenance);
+            verification = await verifyArtifactIntegrity(buffer, provenance);
           }
         } catch {
           // Metadata not available (e.g., local dev without running fetch-catalog.sh)


### PR DESCRIPTION
## Summary
- remove the dead verifyCatalogIntegrity export
- switch CatalogContext to verifyArtifactIntegrity directly
- update integrity tests to cover verifyArtifactIntegrity directly

## Validation
- npm run test -- src/domain/integrity.test.ts src/state/CatalogContext.test.tsx
- npm run build
- rg "verifyCatalogIntegrity" src returned no matches

Linear: GRU-192