### PR TITLE
GRU-205 Footer-Pflichtlinks auf Mobile direkt sichtbar machen

### DIFF
--- a/src/app/AppShell.test.tsx
+++ b/src/app/AppShell.test.tsx
@@ -26,7 +26,9 @@ vi.mock('@/components/TreeNav', () => ({
 }));
 
 vi.mock('@/components/Footer', () => ({
-  Footer: () => <footer>Footer</footer>,
+  Footer: ({ className = '' }: { className?: string }) => (
+    <footer className={className}>Footer</footer>
+  ),
 }));
 
 vi.mock('@/features/home/HomePage', () => ({
@@ -171,5 +173,15 @@ describe('AppShell', () => {
 
     expect(screen.getByText('Vokabular-Detail')).toBeInTheDocument();
     expect(document.title).toBe('security-level — Vokabulare — Grundschutz++ Navigator');
+  });
+
+  it('renders the footer without hiding it below desktop breakpoints', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <AppShell />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Footer')).not.toHaveClass('hidden');
   });
 });

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -380,7 +380,7 @@ export function AppShell() {
                 }
               />
             </Routes>
-          <Footer className="hidden lg:block" />
+          <Footer />
         </main>
       </div>
     </div>

--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -172,4 +172,22 @@ describe('Footer', () => {
     expect(brand).toBeInTheDocument();
     expect(brand.textContent).not.toMatch(/Pre-Release|v\d/);
   });
+
+  it('keeps legal and secondary links directly visible on mobile breakpoints', () => {
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>,
+    );
+
+    for (const name of [
+      'Über das Projekt',
+      'Datenschutz',
+      'Impressum',
+      'Lizenzen',
+      'Vokabulare',
+    ]) {
+      expect(screen.getByRole('link', { name }).className).not.toContain('hidden');
+    }
+  });
 });

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -27,15 +27,15 @@ export function Footer({ className = '' }: FooterProps) {
   const verified = verification?.valid;
 
   const secondaryLinkClass =
-    'hidden lg:inline whitespace-nowrap rounded text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-[var(--color-focus-ring)]';
+    'whitespace-nowrap rounded text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-[var(--color-focus-ring)]';
 
   return (
     <footer
-      className={`shrink-0 border-t border-[var(--color-border-default)] bg-[var(--color-surface-base)] px-6 py-3 text-xs text-[var(--color-text-secondary)] ${className}`}
+      className={`shrink-0 border-t border-[var(--color-border-default)] bg-[var(--color-surface-base)] px-4 py-3 text-xs text-[var(--color-text-secondary)] sm:px-6 ${className}`}
       role="contentinfo"
     >
-      <div className="flex flex-row items-center justify-between gap-3 lg:gap-6">
-        <div className="flex min-w-0 items-center gap-3 overflow-hidden">
+      <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between lg:gap-6">
+        <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 overflow-hidden">
           <span className="hidden shrink-0 whitespace-nowrap font-medium tracking-[0.02em] text-[var(--color-text-primary)] xl:inline">
             Grundschutz++ Navigator
           </span>
@@ -53,7 +53,7 @@ export function Footer({ className = '' }: FooterProps) {
           </a>
         </div>
 
-        <div className="flex min-w-0 shrink-0 items-center gap-x-3 text-[var(--color-text-secondary)]">
+        <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-[var(--color-text-secondary)]">
           {catalogVersion && (
             <span className="whitespace-nowrap">{formatDate(catalogVersion)}</span>
           )}


### PR DESCRIPTION
## Summary
- render Footer on all breakpoints instead of hiding it below lg
- make secondary/legal footer links visible on mobile
- switch footer layout to responsive wrapping rows to avoid horizontal scrolling
- add regression tests for visible footer/legal links

## Validation
- npm run test -- src/components/Footer.test.tsx src/app/AppShell.test.tsx
- Browser viewport checks at 320, 375, 768, 1024, and 1440 px: footer visible, Datenschutz/Impressum visible, no horizontal scroll

Linear: GRU-205