### PR TITLE
GRU-211 Footer-Redundanzen konsolidieren

### DIFF
--- a/src/app/AppShell.test.tsx
+++ b/src/app/AppShell.test.tsx
@@ -184,4 +184,31 @@ describe('AppShell', () => {
 
     expect(screen.getByText('Footer')).not.toHaveClass('hidden');
   });
+
+  it('keeps only primary mobile destinations in the drawer', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <AppShell />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
+
+    expect(screen.getByRole('navigation', { name: 'Sektionen' }))
+      .toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Katalog' })).toHaveAttribute(
+      'href',
+      '/katalog',
+    );
+    expect(screen.getByRole('link', { name: 'Suche' })).toHaveAttribute(
+      'href',
+      '/suche',
+    );
+    expect(screen.queryByRole('navigation', { name: 'Weitere Seiten' }))
+      .not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Datenschutz' }))
+      .not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Impressum' }))
+      .not.toBeInTheDocument();
+  });
 });

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -9,10 +9,6 @@ import {
   IconShield,
   IconLayoutList,
   IconSearch,
-  IconDocument,
-  IconInfo,
-  IconShieldCheck,
-  IconScale,
   IconX,
 } from '@/components/icons';
 import type { TreeItem } from '@/components/TreeNav';
@@ -248,34 +244,6 @@ export function AppShell() {
                     }
                   >
                     <Icon className="w-4 h-4" aria-hidden="true" />
-                    {label}
-                  </NavLink>
-                ))}
-              </nav>
-
-              {/* Mobile info links */}
-              <nav className="md:hidden border-b border-slate-200" aria-label="Weitere Seiten">
-                {[
-                  { to: '/vokabular', label: 'Vokabulare', Icon: IconDocument },
-                  { to: '/about', label: 'Über das Projekt', Icon: IconInfo },
-                  { to: '/datenschutz', label: 'Datenschutz', Icon: IconShieldCheck },
-                  { to: '/impressum', label: 'Impressum', Icon: IconDocument },
-                  { to: '/lizenzen', label: 'Lizenzen', Icon: IconScale },
-                ].map(({ to, label, Icon }) => (
-                  <NavLink
-                    key={to}
-                    to={to}
-                    onClick={() => setSideNavOpen(false)}
-                    className={({ isActive }) =>
-                      [
-                        'flex items-center gap-3 px-4 py-2.5 text-[13px] transition-colors',
-                        isActive
-                          ? 'text-primary-main font-medium'
-                          : 'text-slate-600 hover:bg-slate-50',
-                      ].join(' ')
-                    }
-                  >
-                    <Icon className="w-3.5 h-3.5" aria-hidden="true" />
                     {label}
                   </NavLink>
                 ))}

--- a/src/features/home/HomePage.test.tsx
+++ b/src/features/home/HomePage.test.tsx
@@ -123,7 +123,7 @@ describe('HomePage', () => {
     mockedUseCatalog.mockReturnValue(catalogState());
   });
 
-  it('renders the production hero copy, computed statistics and metadata', () => {
+  it('renders the production hero copy and computed statistics without duplicate provenance metadata', () => {
     renderHome();
 
     expect(
@@ -136,8 +136,10 @@ describe('HomePage', () => {
     expect(
       screen.getByText(/2 Praktiken\s+·\s+3 Themen\s+·\s+7 Kontrollen/),
     ).toHaveClass('tabular-nums');
-    expect(screen.getByText(/Katalog-Stand: 26\. März 2026/))
-      .toHaveTextContent(/verifiziert\s+·\s+Quelle: BSI Stand-der-Technik-Bibliothek/);
+    expect(screen.queryByText(/Katalog-Stand:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/verifiziert/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Quelle: BSI Stand-der-Technik-Bibliothek/))
+      .not.toBeInTheDocument();
 
     expect(screen.queryByRole('navigation', { name: 'Primäre Aktionen' }))
       .not.toBeInTheDocument();
@@ -157,7 +159,7 @@ describe('HomePage', () => {
       .not.toBeInTheDocument();
   });
 
-  it('renders the unverified hero state with the warning color token', () => {
+  it('does not render verification metadata in the hero when catalog verification fails', () => {
     mockedUseCatalog.mockReturnValue(catalogState({
       verification: {
         valid: false,
@@ -170,8 +172,7 @@ describe('HomePage', () => {
 
     renderHome();
 
-    expect(screen.getByText('nicht verifiziert'))
-      .toHaveClass('text-[var(--color-warning)]');
+    expect(screen.queryByText('nicht verifiziert')).not.toBeInTheDocument();
   });
 
   it('renders the compact Grundschutz++ explanation with a project link', () => {

--- a/src/features/home/HomePage.tsx
+++ b/src/features/home/HomePage.tsx
@@ -2,24 +2,8 @@ import { Link } from 'react-router-dom';
 import { IconShield } from '@/components/icons';
 import { useCatalog } from '@/hooks/useCatalog';
 
-function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toLocaleDateString('de-DE', {
-      day: 'numeric',
-      month: 'short',
-      year: 'numeric',
-    });
-  } catch {
-    return iso;
-  }
-}
-
 export function HomePage() {
-  const { catalog, loading, provenance, verification } = useCatalog();
-  const commitDate = provenance?.source.commit_date;
-  const catalogVersion =
-    commitDate && commitDate !== 'unknown' ? commitDate : undefined;
-  const verified = verification?.valid;
+  const { catalog, loading } = useCatalog();
   const catalogStats = catalog
     ? {
         practices: catalog.practices.length,
@@ -54,29 +38,6 @@ export function HomePage() {
               Kontrollen
             </p>
           )}
-          <p className="type-meta mt-2 text-[var(--color-text-secondary)]">
-            {catalogVersion && (
-              <>
-                Katalog-Stand: {formatDate(catalogVersion)}
-                <span aria-hidden="true"> &middot; </span>
-              </>
-            )}
-            {verified !== undefined && (
-              <>
-                <span
-                  className={
-                    verified
-                      ? 'text-[var(--color-success)]'
-                      : 'text-[var(--color-warning)]'
-                  }
-                >
-                  {verified ? 'verifiziert' : 'nicht verifiziert'}
-                </span>
-                <span aria-hidden="true"> &middot; </span>
-              </>
-            )}
-            Quelle: BSI Stand-der-Technik-Bibliothek
-          </p>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- remove the redundant mobile drawer secondary-link section
- keep the mobile drawer focused on Katalog and Suche
- remove duplicated catalog provenance/status metadata from the homepage hero
- keep the homepage catalog statistics and footer behavior intact

## Validation
- npm run test -- src/app/AppShell.test.tsx src/features/home/HomePage.test.tsx src/components/Footer.test.tsx
- npm run lint
- npm run build
- Browser check at 375px: drawer contains Katalog/Suche only, homepage header has no provenance metadata, footer legal links remain visible without interaction, no horizontal scroll

Depends on PR #23.

Linear: GRU-211